### PR TITLE
update notifications to include errors

### DIFF
--- a/AFIncrementalStore/AFIncrementalStore.swift
+++ b/AFIncrementalStore/AFIncrementalStore.swift
@@ -828,9 +828,6 @@ open class AFIncrementalStore: NSIncrementalStore {
 
                 guard error == nil else {
                     operationErrors[updatedObject.objectID] = error! as NSError
-                    context?.performAndWait {
-                        context?.refresh(updatedObject, mergeChanges: true)
-                    }
                     operation_dispatch_group.leave()
                     return
 

--- a/AFIncrementalStore/AFIncrementalStore.swift
+++ b/AFIncrementalStore/AFIncrementalStore.swift
@@ -828,6 +828,9 @@ open class AFIncrementalStore: NSIncrementalStore {
 
                 guard error == nil else {
                     operationErrors[updatedObject.objectID] = error! as NSError
+                    context?.performAndWait {
+                        context?.refresh(updatedObject, mergeChanges: true)
+                    }
                     operation_dispatch_group.leave()
                     return
 

--- a/AFIncrementalStore/AFIncrementalStore.swift
+++ b/AFIncrementalStore/AFIncrementalStore.swift
@@ -357,6 +357,11 @@ public extension Notification.Name {
  */
 public let AFIncrementalStoreRequestOperationsKey: String = "AFIncrementalStoreRequestOperations"
 
+/**
+ A key in the `userInfo` dictionary in a `AFIncrementalStoreContextDidFetchRemoteValues` as well as `AFIncrementalStoreContextDidSaveRemoteValues` or `AFIncrementalStoreContextDidFetchNewValuesForObject` or `AFIncrementalStoreContextDidFetchNewValuesForRelationship` notification.
+ The corresponding value is an `NSArray` of `NSError` containing 1 element if there was an error.
+ For the `AFIncrementalStoreContextDidSaveRemoteValues` notification it is a dictionary with `NSManagedObjectID` as keys and `NSError` as elements, to contain any errors with the associated API requests.
+ */
 public let AFIncrementalStoreRequestErrorsKey: String = "AFIncrementalStoreRequestErrors"
 
 /**


### PR DESCRIPTION
I added a new key for the userInfo dictionary.

The "errors" item can be nil, or an array of optional NSError objects.

If the array is not nil, it always contains the same number of elements of the "operations" array. If an operation doesn't have an error, the corresponding error element is nil.

This behaviour is valid only in the "didSave" or "didFetch" notifications, in the "will" counterparts it's always nil.